### PR TITLE
Migrate existing models

### DIFF
--- a/ad.go
+++ b/ad.go
@@ -1,0 +1,40 @@
+package fbintegration
+
+import (
+	facebookLib "github.com/huandu/facebook"
+)
+
+type (
+	//Ad comment pending
+	Ad struct {
+		ID       string
+		Creative Creative
+		Post     Post
+	}
+)
+
+//NewAd comment pending
+func NewAd(result *facebookLib.Result) Ad {
+	var id string
+	var creativeID string
+
+	result.DecodeField("id", &id)
+	result.DecodeField("creative.id", &creativeID)
+
+	ad := Ad{
+		id,
+		Creative{creativeID, "", ""},
+		Post{},
+	}
+
+	return ad
+}
+
+//CreateBatchParams comment pending
+func (a *Ad) CreateBatchParams() facebookLib.Params {
+	return facebookLib.Params{
+		"method":       facebookLib.GET,
+		"relative_url": a.Creative.ID,
+		"fields":       "object_id,object_type,effective_object_story_id",
+	}
+}

--- a/ad_batch.go
+++ b/ad_batch.go
@@ -1,0 +1,34 @@
+package fbintegration
+
+import (
+	facebookLib "github.com/huandu/facebook"
+)
+
+type (
+	//AdBatch comment pending
+	AdBatch struct {
+		Ads []Ad
+	}
+)
+
+//CreativeParams comment pending
+func (a *AdBatch) CreativeParams() []facebookLib.Params {
+	var params []facebookLib.Params
+
+	for i := 0; i < len(a.Ads); i++ {
+		params = append(params, a.Ads[i].Creative.GenerateParams())
+	}
+
+	return params
+}
+
+//PostParams comment pending
+func (a *AdBatch) PostParams() []facebookLib.Params {
+	var params []facebookLib.Params
+
+	for i := 0; i < len(a.Ads); i++ {
+		params = append(params, a.Ads[i].Post.GenerateParams())
+	}
+
+	return params
+}

--- a/brand_ads.go
+++ b/brand_ads.go
@@ -1,0 +1,91 @@
+package fbintegration
+
+import (
+	facebookLib "github.com/huandu/facebook"
+)
+
+type (
+	//BrandAds comment pending
+	BrandAds struct {
+		FBAdAccountID string
+		Ads           []Ad
+		BrandID       int64
+		BrandName     string
+	}
+)
+
+//NewBrandAds comment pending
+func NewBrandAds(adAccountID string, brandID int64, brandName string) BrandAds {
+	var ads []Ad
+
+	return BrandAds{
+		adAccountID,
+		ads,
+		brandID,
+		brandName,
+	}
+}
+
+//GenerateParams comment pending
+func (ba *BrandAds) GenerateParams() facebookLib.Params {
+	return facebookLib.Params{
+		"date_preset": "lifetime",
+		"limit":       40,
+		"fields":      "fields=id,creative{id, object_id}",
+	}
+}
+
+//Add comment pending
+func (ba *BrandAds) Add(ad Ad) {
+	ba.Ads = append(ba.Ads, ad)
+}
+
+//GenerateSlices comment pending
+func (ba *BrandAds) GenerateSlices(size int) []AdBatch {
+	var adBatch []AdBatch
+
+	batchAmount := len(ba.Ads) / size
+	startIndex := 0
+	endIndex := size
+
+	for i := 0; i < batchAmount; i++ {
+		batch := AdBatch{ba.Ads[startIndex:endIndex]}
+		adBatch = append(adBatch, batch)
+
+		startIndex += size
+		endIndex += size
+	}
+
+	return adBatch
+}
+
+//FindByCreativeID comment pending
+func (ba *BrandAds) FindByCreativeID(creativeID string) *Ad {
+	for i, ad := range ba.Ads {
+		if ad.Creative.ID == creativeID {
+			return &ba.Ads[i]
+		}
+	}
+
+	return nil
+}
+
+//FindByPostID comment pending
+func (ba *BrandAds) FindByPostID(postID string) *Ad {
+	for i, ad := range ba.Ads {
+		if ad.Creative.PostID == postID {
+			return &ba.Ads[i]
+		}
+	}
+	return nil
+}
+
+//FindByObjectID comment pending
+func (ba *BrandAds) FindByObjectID(objectID string) *Ad {
+	for i, ad := range ba.Ads {
+		if ad.Post.ObjectID == objectID {
+			return &ba.Ads[i]
+		}
+	}
+	return nil
+}

--- a/creative.go
+++ b/creative.go
@@ -5,7 +5,7 @@ import (
 	facebookLib "github.com/huandu/facebook"
 )
 
-const VIDEO_TYPE = "VIDEO"
+const videoType = "VIDEO"
 
 type (
 	//Creative comment pending
@@ -32,7 +32,7 @@ func (c *Creative) GenerateParams() facebookLib.Params {
 
 //IsVideo comment pending
 func (c *Creative) IsVideo() bool {
-	if c.ObjectType == VIDEO_TYPE {
+	if c.ObjectType == videoType {
 		return true
 	}
 	return false

--- a/creative.go
+++ b/creative.go
@@ -1,0 +1,39 @@
+package fbintegration
+
+import (
+	"fmt"
+	facebookLib "github.com/huandu/facebook"
+)
+
+const VIDEO_TYPE = "VIDEO"
+
+type (
+	//Creative comment pending
+	Creative struct {
+		ID         string `facebook:"id"`
+		ObjectType string `facebook:"object_type"`
+		PostID     string `facebook:"effective_object_story_id"`
+	}
+)
+
+func NewCreativeFromResult(result facebookLib.Result) Creative {
+	var creative Creative
+	result.DecodeField("", &creative)
+	return creative
+}
+
+//GenerateParams comments pending
+func (c *Creative) GenerateParams() facebookLib.Params {
+	return facebookLib.Params{
+		"method":       facebookLib.GET,
+		"relative_url": fmt.Sprintf("%s?fields=%s", c.ID, "object_id,object_type,effective_object_story_id"),
+	}
+}
+
+//IsVideo comment pending
+func (c *Creative) IsVideo() bool {
+	if c.ObjectType == VIDEO_TYPE {
+		return true
+	}
+	return false
+}

--- a/post_data.go
+++ b/post_data.go
@@ -1,0 +1,21 @@
+package fbintegration
+
+type (
+	// PostData comment pending
+	PostData struct {
+		Impressions        int            `json:"impressions"`
+		PaidImpressions    int            `json:"paid_impressions"`
+		OrganicImpressions int            `json:"organic_impressions"`
+		Reach              int            `json:"reach"`
+		PaidReach          int            `json:"paid_reach"`
+		OrganicReach       int            `json:"organic_reach"`
+		VideoViews         int            `json:"video_views"`
+		PaidVideoViews     int            `json:"paid_video_views"`
+		OrganicVideoViews  int            `json:"organic_video_views"`
+		UniqueVideoViews   int            `json:"unique_video_views"`
+		MinutesViewed      int            `json:"minutes_viewed"`
+		AverageDuration    int            `json:"average_duration"`
+		ReactionsTotal     int            `json:"reactions_total"`
+		Reactions          map[string]int `json:"reactions"`
+	}
+)

--- a/post_results.go
+++ b/post_results.go
@@ -1,0 +1,14 @@
+package fbintegration
+
+import (
+	facebookLib "github.com/huandu/facebook"
+)
+
+type (
+	// PostResults comment pending
+	PostResults struct {
+		Insights          *facebookLib.Result
+		ReactionBreakdown []*facebookLib.Result
+		TotalReactions    *facebookLib.Result
+	}
+)


### PR DESCRIPTION
### Problem

`fb-publisher` isn't currently using `fb-integration` as some of the models it requires are still in the repo, we need to move them over and add some missing fields whilst generating the payload for the message that get's put on the queue. Also when integrating this lib because the structs for `Data` and `Results` on a post are embedded and the `Post` struct is shared between `fb-publisher` and `fb-consumer` when the JSON is encoded we end up with a number of empty fields in the payload which looks strange as `fb-publisher` doesn't have any notion of anything for the `Data` struct.

### Solution

* Move and merge the exists classes in `fb-publisher`
* Move the two embedded structs from `Post` so we can have empty references and not have them included in the payload when used by `fb-publisher`.

### Notes

* https://trello.com/c/bYQhGrj0/125-fp-add-name-into-payload
* https://trello.com/c/PDSie0AA/128-fbp-pass-ad-id-through-to-fbc-in-payload
* https://trello.com/c/RM51sxqr/129-fbi-migrate-models-from-fp