### PR TITLE
Adds advert insights in

### DIFF
--- a/ad.go
+++ b/ad.go
@@ -1,6 +1,7 @@
 package fbintegration
 
 import (
+	"fmt"
 	facebookLib "github.com/huandu/facebook"
 )
 
@@ -8,8 +9,8 @@ type (
 	// Ad comment pending
 	Ad struct {
 		ID       string
-		Creative Creative
-		Post     Post
+		Creative *Creative
+		Post     *Post
 	}
 )
 
@@ -23,8 +24,8 @@ func NewAd(result *facebookLib.Result) Ad {
 
 	ad := Ad{
 		id,
-		Creative{creativeID, "", ""},
-		Post{},
+		&Creative{creativeID, "", ""},
+		&Post{},
 	}
 
 	return ad
@@ -36,5 +37,21 @@ func (a *Ad) CreateBatchParams() facebookLib.Params {
 		"method":       facebookLib.GET,
 		"relative_url": a.Creative.ID,
 		"fields":       "object_id,object_type,effective_object_story_id",
+	}
+}
+
+// CreateInsightParams comment pending
+func (a *Ad) CreateInsightParams() facebookLib.Params {
+	return facebookLib.Params{
+		"method":       facebookLib.GET,
+		"relative_url": fmt.Sprintf("%s/insights?fields=clicks,total_unique_actions,spend&date_preset=lifetime", a.ID),
+	}
+}
+
+//CreateBreakdownInsightParams comment pending
+func (a *Ad) CreateBreakdownInsightParams() facebookLib.Params {
+	return facebookLib.Params{
+		"method":       facebookLib.GET,
+		"relative_url": fmt.Sprintf("%s/insights?fields=reach&date_preset=lifetime&breakdowns=age,gender", a.ID),
 	}
 }

--- a/audience_split.go
+++ b/audience_split.go
@@ -1,0 +1,13 @@
+package fbintegration
+
+type (
+	// AudienceSplit commend pending
+	AudienceSplit struct {
+		Gender   string `json:"gender"`
+		AgeRange string `json:"age_range"`
+		Value    string `json:"value"`
+	}
+)
+
+// NewAudienceBreakdownsFromResults comment pending
+//func NewAudienceBreakdownsFromResults()

--- a/audience_split.go
+++ b/audience_split.go
@@ -1,5 +1,10 @@
 package fbintegration
 
+import (
+	"fmt"
+	facebookLib "github.com/huandu/facebook"
+)
+
 type (
 	// AudienceSplit commend pending
 	AudienceSplit struct {
@@ -9,5 +14,16 @@ type (
 	}
 )
 
-// NewAudienceBreakdownsFromResults comment pending
-//func NewAudienceBreakdownsFromResults()
+// NewAudienceSplitFromResult comment pending
+func NewAudienceSplitFromResult(results *facebookLib.Result, recordIndex int) *AudienceSplit {
+	return &AudienceSplit{
+		getResultValue(results, recordIndex, "gender"),
+		getResultValue(results, recordIndex, "age"),
+		getResultValue(results, recordIndex, "reach"),
+	}
+}
+
+func getResultValue(results *facebookLib.Result, recordIndex int, key string) string {
+	query := fmt.Sprintf("data.%d.%s", recordIndex, key)
+	return results.Get(query).(string)
+}

--- a/post.go
+++ b/post.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 
 	facebookLib "github.com/huandu/facebook"
 )
@@ -150,6 +151,29 @@ func (p *Post) ParseResults() {
 	p.Data.Comments = p.getComments()
 
 	p.Data.Shares = p.getShares()
+
+	totalClicks := p.getAdInsightsValue("clicks")
+	if totalClicks != nil {
+		int64Value, err := strconv.ParseInt(totalClicks.(string), 10, 32)
+		if err == nil {
+			p.Data.TotalClicks = int64Value
+		}
+	}
+
+	totalSpend := p.getAdInsightsValue("spend")
+	if totalSpend != nil {
+		p.Data.Spend = totalSpend.(float64)
+	}
+
+	uniquePeopleEngaged := p.getAdInsightsValue("total_unique_actions")
+	if uniquePeopleEngaged != nil {
+		int64Value, err := strconv.ParseInt(uniquePeopleEngaged.(string), 10, 32)
+		if err == nil {
+			p.Data.UniquePeopleEngaged = int64Value
+		}
+	}
+
+	p.Data.AudienceSplit = p.generateAudienceSplit()
 }
 
 // ReactionTypes comment pending
@@ -167,6 +191,30 @@ func (p *Post) ToJSON() (string, error) {
 	}
 
 	return string(b), nil
+}
+
+func (p Post) generateAudienceSplit() []*AudienceSplit {
+	data := p.Results.AdBreakdownInsights.Get("data")
+	slice := reflect.ValueOf(data)
+
+	audienceSplits := make([]*AudienceSplit, slice.Len())
+
+	for i := 0; i < slice.Len(); i++ {
+		query := "data.%d.%s"
+		genderQuery := fmt.Sprintf(query, i, "gender")
+		ageQuery := fmt.Sprintf(query, i, "age")
+		valueQuery := fmt.Sprintf(query, i, "reach")
+
+		audienceSplit := &AudienceSplit{
+			p.Results.AdBreakdownInsights.Get(genderQuery).(string),
+			p.Results.AdBreakdownInsights.Get(ageQuery).(string),
+			p.Results.AdBreakdownInsights.Get(valueQuery).(string),
+		}
+
+		audienceSplits[i] = audienceSplit
+	}
+
+	return audienceSplits
 }
 
 func (p Post) getComments() int {
@@ -202,6 +250,17 @@ func (p Post) getShares() int {
 	slice := reflect.ValueOf(data)
 
 	return slice.Len()
+}
+
+func (p Post) getAdInsightsValue(key string) interface{} {
+	query := fmt.Sprintf("data.0.%s", key)
+	value := p.Results.AdInsights.Get(query)
+
+	if value != nil {
+		return value
+	}
+
+	return nil
 }
 
 func (p Post) getReactionsTotal(result *facebookLib.Result) int {

--- a/post.go
+++ b/post.go
@@ -196,22 +196,10 @@ func (p *Post) ToJSON() (string, error) {
 func (p Post) generateAudienceSplit() []*AudienceSplit {
 	data := p.Results.AdBreakdownInsights.Get("data")
 	slice := reflect.ValueOf(data)
-
 	audienceSplits := make([]*AudienceSplit, slice.Len())
 
 	for i := 0; i < slice.Len(); i++ {
-		query := "data.%d.%s"
-		genderQuery := fmt.Sprintf(query, i, "gender")
-		ageQuery := fmt.Sprintf(query, i, "age")
-		valueQuery := fmt.Sprintf(query, i, "reach")
-
-		audienceSplit := &AudienceSplit{
-			p.Results.AdBreakdownInsights.Get(genderQuery).(string),
-			p.Results.AdBreakdownInsights.Get(ageQuery).(string),
-			p.Results.AdBreakdownInsights.Get(valueQuery).(string),
-		}
-
-		audienceSplits[i] = audienceSplit
+		audienceSplits[i] = NewAudienceSplitFromResult(p.Results.AdBreakdownInsights, i)
 	}
 
 	return audienceSplits

--- a/post_batch.go
+++ b/post_batch.go
@@ -82,3 +82,27 @@ func (p PostBatch) TotalReactionsParams() []facebookLib.Params {
 
 	return params
 }
+
+// TotalAdInsightsParams comment pending
+func (p PostBatch) TotalAdInsightsParams() []facebookLib.Params {
+	var params []facebookLib.Params
+
+	for i := 0; i < len(p.Posts); i++ {
+		ad := Ad{ID: p.Posts[i].AdID}
+		params = append(params, ad.CreateInsightParams())
+	}
+
+	return params
+}
+
+// TotalAdInsightsBreakDownsParams comment pending
+func (p PostBatch) TotalAdInsightsBreakDownParams() []facebookLib.Params {
+	var params []facebookLib.Params
+
+	for i := 0; i < len(p.Posts); i++ {
+		ad := Ad{ID: p.Posts[i].AdID}
+		params = append(params, ad.CreateBreakdownInsightParams())
+	}
+
+	return params
+}

--- a/post_data.go
+++ b/post_data.go
@@ -3,21 +3,25 @@ package fbintegration
 type (
 	// PostData comment pending
 	PostData struct {
-		Impressions        int            `json:"impressions"`
-		PaidImpressions    int            `json:"paid_impressions"`
-		OrganicImpressions int            `json:"organic_impressions"`
-		Reach              int            `json:"reach"`
-		PaidReach          int            `json:"paid_reach"`
-		OrganicReach       int            `json:"organic_reach"`
-		VideoViews         int            `json:"video_views"`
-		PaidVideoViews     int            `json:"paid_video_views"`
-		OrganicVideoViews  int            `json:"organic_video_views"`
-		UniqueVideoViews   int            `json:"unique_video_views"`
-		MinutesViewed      int            `json:"minutes_viewed"`
-		AverageDuration    int            `json:"average_duration"`
-		ReactionsTotal     int            `json:"reactions_total"`
-		Reactions          map[string]int `json:"reactions"`
-		Comments           int            `json:"comments"`
-		Shares             int            `json:"shares"`
+		Impressions         int              `json:"impressions"`
+		PaidImpressions     int              `json:"paid_impressions"`
+		OrganicImpressions  int              `json:"organic_impressions"`
+		Reach               int              `json:"reach"`
+		PaidReach           int              `json:"paid_reach"`
+		OrganicReach        int              `json:"organic_reach"`
+		VideoViews          int              `json:"video_views"`
+		PaidVideoViews      int              `json:"paid_video_views"`
+		OrganicVideoViews   int              `json:"organic_video_views"`
+		UniqueVideoViews    int              `json:"unique_video_views"`
+		MinutesViewed       int              `json:"minutes_viewed"`
+		AverageDuration     int              `json:"average_duration"`
+		ReactionsTotal      int              `json:"reactions_total"`
+		Reactions           map[string]int   `json:"reactions"`
+		Comments            int              `json:"comments"`
+		Shares              int              `json:"shares"`
+		TotalClicks         int64            `json:"total_clicks"`
+		UniquePeopleEngaged int64            `json:"unique_people_engaged"`
+		Spend               float64          `json:"spend"`
+		AudienceSplit       []*AudienceSplit `json:"audience_split"`
 	}
 )

--- a/post_results.go
+++ b/post_results.go
@@ -7,9 +7,11 @@ import (
 type (
 	// PostResults comment pending
 	PostResults struct {
-		Engagement        []*facebookLib.Result
-		Insights          *facebookLib.Result
-		ReactionBreakdown []*facebookLib.Result
-		TotalReactions    *facebookLib.Result
+		Engagement          []*facebookLib.Result
+		Insights            *facebookLib.Result
+		AdInsights          *facebookLib.Result
+		AdBreakdownInsights *facebookLib.Result
+		ReactionBreakdown   []*facebookLib.Result
+		TotalReactions      *facebookLib.Result
 	}
 )


### PR DESCRIPTION
### Problem

We need to get the insight data for an advert and add this to the `Post` that can be used to create the insights for a post and also the summary.

### Solution

* Add methods on `Ad` class for generating params for advert insights and breakdowns.
* Update `Post` parse method to add these new insights.
* Add `AudienceSplit` struct for storing the audience splits from the age/gender breakdown api call.
* Update `PostBatch` to include methods for generating batches for both API calls.

### Notes

* https://trello.com/c/InnTeXEc/193-fbi-add-classes-needed-for-last-batch-of-insights