### PR TITLE
Change audience split to be hash of age ranges with percentages

### DIFF
--- a/audience_split.go
+++ b/audience_split.go
@@ -1,13 +1,22 @@
 package fbintegration
 
 import (
+	"encoding/json"
 	"fmt"
 	facebookLib "github.com/huandu/facebook"
+	"reflect"
+	"strconv"
 )
 
 type (
-	// AudienceSplit commend pending
+	// AudienceSplit comment pending
 	AudienceSplit struct {
+		Total float64
+		Data  []AudienceSplitItem
+	}
+
+	// AudienceSplitItem comment pending
+	AudienceSplitItem struct {
 		Gender   string `json:"gender"`
 		AgeRange string `json:"age_range"`
 		Value    string `json:"value"`
@@ -15,12 +24,53 @@ type (
 )
 
 // NewAudienceSplitFromResult comment pending
-func NewAudienceSplitFromResult(results *facebookLib.Result, recordIndex int) *AudienceSplit {
-	return &AudienceSplit{
-		getResultValue(results, recordIndex, "gender"),
-		getResultValue(results, recordIndex, "age"),
-		getResultValue(results, recordIndex, "reach"),
+func NewAudienceSplitFromResult(results *facebookLib.Result, total float64) AudienceSplit {
+	audienceSplit := AudienceSplit{Total: total}
+	data := results.Get("data")
+	slice := reflect.ValueOf(data)
+
+	for i := 0; i < slice.Len(); i++ {
+		audienceSplitItem := AudienceSplitItem{
+			getResultValue(results, i, "gender"),
+			getResultValue(results, i, "age"),
+			getResultValue(results, i, "reach"),
+		}
+		audienceSplit.Push(audienceSplitItem)
 	}
+
+	return audienceSplit
+}
+
+func (as *AudienceSplit) Push(audienceSplitItem AudienceSplitItem) {
+	as.Data = append(as.Data, audienceSplitItem)
+}
+
+func (as AudienceSplit) MarshalJSON() ([]byte, error) {
+	audienceSplit := map[string]map[string]float64{}
+
+	for _, audienceSplitItem := range as.Data {
+		_, exists := audienceSplit[audienceSplitItem.AgeRange]
+
+		if !exists {
+			audienceSplit[audienceSplitItem.AgeRange] = map[string]float64{"male": 0, "female": 0}
+		}
+
+		value, err := strconv.ParseFloat(audienceSplitItem.Value, 64)
+
+		if err != nil {
+			return []byte{}, err
+		}
+
+		audienceSplit[audienceSplitItem.AgeRange][audienceSplitItem.Gender] = (value / as.Total) * 100
+	}
+
+	json, err := json.Marshal(audienceSplit)
+
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return json, nil
 }
 
 func getResultValue(results *facebookLib.Result, recordIndex int, key string) string {

--- a/post.go
+++ b/post.go
@@ -185,7 +185,7 @@ func (p *Post) ParseResults() {
 	if p.Data.OrganicVideoViews > 0 || p.Data.PaidVideoViews > 0 {
 		p.Data.VideoViewCost = p.Data.Spend / (p.Data.OrganicVideoViews + p.Data.PaidVideoViews)
 	}
-	p.Data.AudienceSplit = p.generateAudienceSplit()
+	p.Data.AudienceSplit = p.generateAudienceSplit(p.Data.Reach + p.Data.OrganicImpressions)
 }
 
 // ReactionTypes comment pending
@@ -205,16 +205,8 @@ func (p *Post) ToJSON() (string, error) {
 	return string(b), nil
 }
 
-func (p Post) generateAudienceSplit() []*AudienceSplit {
-	data := p.Results.AdBreakdownInsights.Get("data")
-	slice := reflect.ValueOf(data)
-	audienceSplits := make([]*AudienceSplit, slice.Len())
-
-	for i := 0; i < slice.Len(); i++ {
-		audienceSplits[i] = NewAudienceSplitFromResult(p.Results.AdBreakdownInsights, i)
-	}
-
-	return audienceSplits
+func (p Post) generateAudienceSplit(reach float64) AudienceSplit {
+	return NewAudienceSplitFromResult(p.Results.AdBreakdownInsights, reach)
 }
 
 func (p Post) getComments() float64 {

--- a/post_data.go
+++ b/post_data.go
@@ -26,6 +26,6 @@ type (
 		Actions                       float64            `json:"actions"`
 		EngagementPercentPeopleViewed float64            `json:"engagement_percent_people_viewed"`
 		ViewRate                      float64            `json:"view_rate"`
-		AudienceSplit                 []*AudienceSplit   `json:"audience_split"`
+		AudienceSplit                 AudienceSplit      `json:"audience_split"`
 	}
 )


### PR DESCRIPTION
### Problem

The audience split wasn't in a useful format, we need to know the percentages for each gender in each age range.

### Solution

* Move `AudienceSplit` struct to `AudienceSplitItem` struct.
* Create `AudienceSplit` struct to store a number of `AudienceSplitItem`'s and calculate the percentages when the object is being marshalled.

### Notes

* https://trello.com/c/UgQWfJDz/264-fbi-change-structure-of-audience-split