### PR TITLE
Account for keys not existing

### DIFF
--- a/post.go
+++ b/post.go
@@ -280,7 +280,11 @@ func (p Post) getActionTypeTotal(actionType string) float64 {
 	postStories := p.getInsightsValue("post_stories_by_action_type")
 	reflectedMap := reflect.ValueOf(postStories["value"])
 	valuesMap := reflectedMap.Interface().(map[string]interface{})
-	return valuesMap[actionType].(float64)
+	value := valuesMap[actionType]
+	if value != nil {
+		return valuesMap[actionType].(float64)
+	}
+	return 0
 }
 
 func (p Post) getReactionsTotal(result *facebookLib.Result) float64 {


### PR DESCRIPTION
### Problem

Some posts may not have any data under the `post_stories_by_action_type` type.

### Solution

* Account for it and return 0 if nothing exists.

### Notes

* https://trello.com/c/PGRdAwzb/326-fbi-account-for-action-type-missing