### PR TITLE
Create params structs to encapsulate version setting

### DIFF
--- a/ad.go
+++ b/ad.go
@@ -36,34 +36,21 @@ func NewAd(result *facebookLib.Result) Ad {
 }
 
 // CreateBatchParams comment pending
-func (a *Ad) CreateBatchParams() facebookLib.Params {
-	return facebookLib.Params{
-		"method":       facebookLib.GET,
-		"relative_url": a.Creative.ID,
-		"fields":       "object_id,object_type,effective_object_story_id",
-	}
+func (a *Ad) CreateBatchParams() BatchParams {
+	return NewBatchParams(fmt.Sprintf("%s?fields=object_id,object_type,effective_object_story_id", a.Creative.ID))
 }
 
 // CreateInsightParams comment pending
-func (a *Ad) CreateInsightParams() facebookLib.Params {
-	return facebookLib.Params{
-		"method":       facebookLib.GET,
-		"relative_url": fmt.Sprintf("%s/insights?fields=unique_actions,reach,spend&date_preset=lifetime", a.ID),
-	}
+func (a *Ad) CreateInsightParams() BatchParams {
+	return NewBatchParams(fmt.Sprintf("%s/insights?fields=unique_actions,reach,spend&date_preset=lifetime", a.ID))
 }
 
 // CreateBreakdownInsightParams comment pending
-func (a *Ad) CreateBreakdownInsightParams() facebookLib.Params {
-	return facebookLib.Params{
-		"method":       facebookLib.GET,
-		"relative_url": fmt.Sprintf("%s/insights?fields=reach&date_preset=lifetime&breakdowns=age,gender", a.ID),
-	}
+func (a *Ad) CreateBreakdownInsightParams() BatchParams {
+	return NewBatchParams(fmt.Sprintf("%s/insights?fields=reach&date_preset=lifetime&breakdowns=age,gender", a.ID))
 }
 
 // CreateTargetingParams comment pending
-func (a *Ad) CreateTargetingParams() facebookLib.Params {
-	return facebookLib.Params{
-		"method":       facebookLib.GET,
-		"relative_url": fmt.Sprintf("%s?fields=targeting&date_preset=lifetime", a.AdsetID),
-	}
+func (a *Ad) CreateTargetingParams() BatchParams {
+	return NewBatchParams(fmt.Sprintf("%s?fields=targeting&date_preset=lifetime", a.AdsetID))
 }

--- a/ad_batch.go
+++ b/ad_batch.go
@@ -1,9 +1,5 @@
 package fbintegration
 
-import (
-	facebookLib "github.com/huandu/facebook"
-)
-
 type (
 	// AdBatch comment pending
 	AdBatch struct {
@@ -12,8 +8,8 @@ type (
 )
 
 // CreativeParams comment pending
-func (a *AdBatch) CreativeParams() []facebookLib.Params {
-	var params []facebookLib.Params
+func (a *AdBatch) CreativeParams() []BatchParams {
+	var params []BatchParams
 
 	for i := 0; i < len(a.Ads); i++ {
 		params = append(params, a.Ads[i].Creative.GenerateParams())
@@ -23,8 +19,8 @@ func (a *AdBatch) CreativeParams() []facebookLib.Params {
 }
 
 // PostParams comment pending
-func (a *AdBatch) PostParams() []facebookLib.Params {
-	var params []facebookLib.Params
+func (a *AdBatch) PostParams() []BatchParams {
+	var params []BatchParams
 
 	for i := 0; i < len(a.Ads); i++ {
 		params = append(params, a.Ads[i].Post.GenerateParams())

--- a/api.go
+++ b/api.go
@@ -22,10 +22,15 @@ func NewAPI() API {
 }
 
 // Batch comment pending
-func (f *API) Batch(params ...facebookLib.Params) ([]*APIResponse, *Error) {
+func (f *API) Batch(params ...BatchParams) ([]*APIResponse, *Error) {
 	var apiResponses []*APIResponse
+	var fbBatchParams []facebookLib.Params
 
-	results, err := f.Session.BatchApi(params...)
+	for _, param := range params {
+		fbBatchParams = append(fbBatchParams, param.ToFBParams())
+	}
+
+	results, err := f.Session.BatchApi(fbBatchParams...)
 
 	if err != nil {
 		return []*APIResponse{}, NewError(err)
@@ -46,8 +51,8 @@ func (f *API) Batch(params ...facebookLib.Params) ([]*APIResponse, *Error) {
 }
 
 // Get comment pending
-func (f *API) Get(path string, params facebookLib.Params) (*APIResponse, *Error) {
-	results, err := f.Session.Get(path, params)
+func (f *API) Get(params Params) (*APIResponse, *Error) {
+	results, err := f.Session.Get(params.Endpoint, params.ToFBParams())
 
 	if err != nil {
 		wrappedError := NewError(err)

--- a/api.go
+++ b/api.go
@@ -27,7 +27,7 @@ func (f *API) Batch(params ...BatchParams) ([]*APIResponse, *Error) {
 	var fbBatchParams []facebookLib.Params
 
 	for _, param := range params {
-		fbBatchParams = append(fbBatchParams, param.ToFBParams())
+		fbBatchParams = append(fbBatchParams, param.ToFbParams())
 	}
 
 	results, err := f.Session.BatchApi(fbBatchParams...)
@@ -52,7 +52,7 @@ func (f *API) Batch(params ...BatchParams) ([]*APIResponse, *Error) {
 
 // Get comment pending
 func (f *API) Get(params Params) (*APIResponse, *Error) {
-	results, err := f.Session.Get(params.Endpoint, params.ToFBParams())
+	results, err := f.Session.Get(params.Endpoint, params.ToFbParams())
 
 	if err != nil {
 		wrappedError := NewError(err)

--- a/brand_ads.go
+++ b/brand_ads.go
@@ -1,7 +1,7 @@
 package fbintegration
 
 import (
-	facebookLib "github.com/huandu/facebook"
+	"fmt"
 )
 
 type (
@@ -27,12 +27,12 @@ func NewBrandAds(adAccountID string, brandID int64, brandName string) BrandAds {
 }
 
 // GenerateParams comment pending
-func (ba *BrandAds) GenerateParams() facebookLib.Params {
-	return facebookLib.Params{
+func (ba *BrandAds) GenerateParams(adAccountID string) Params {
+	return NewParams(fmt.Sprintf("/act_%s/ads", adAccountID), map[string]interface{}{
 		"date_preset": "lifetime",
 		"limit":       40,
 		"fields":      "fields=id,creative{id, object_id},adset",
-	}
+	})
 }
 
 // Add comment pending

--- a/creative.go
+++ b/creative.go
@@ -25,11 +25,8 @@ func NewCreativeFromResult(result facebookLib.Result) Creative {
 }
 
 // GenerateParams comments pending
-func (c *Creative) GenerateParams() facebookLib.Params {
-	return facebookLib.Params{
-		"method":       facebookLib.GET,
-		"relative_url": fmt.Sprintf("%s?fields=%s", c.ID, "object_id,object_type,effective_object_story_id"),
-	}
+func (c *Creative) GenerateParams() BatchParams {
+	return NewBatchParams(fmt.Sprintf("%s?fields=%s", c.ID, "object_id,object_type,effective_object_story_id"))
 }
 
 // IsVideo comment pending

--- a/demographic_split.go
+++ b/demographic_split.go
@@ -48,8 +48,6 @@ func (as *DemographicSplit) Push(demographicSplitItem DemographicSplitItem) {
 func (as DemographicSplit) MarshalJSON() ([]byte, error) {
 	demographicSplit := map[string]map[string]float64{}
 
-	fmt.Sprintf("%s", as.Data)
-
 	for _, demographicSplitItem := range as.Data {
 		_, exists := demographicSplit[demographicSplitItem.AgeRange]
 

--- a/demographic_split.go
+++ b/demographic_split.go
@@ -48,6 +48,8 @@ func (as *DemographicSplit) Push(demographicSplitItem DemographicSplitItem) {
 func (as DemographicSplit) MarshalJSON() ([]byte, error) {
 	demographicSplit := map[string]map[string]float64{}
 
+	fmt.Sprintf("%s", as.Data)
+
 	for _, demographicSplitItem := range as.Data {
 		_, exists := demographicSplit[demographicSplitItem.AgeRange]
 

--- a/params.go
+++ b/params.go
@@ -1,0 +1,44 @@
+package fbintegration
+
+import (
+	"fmt"
+	facebookLib "github.com/huandu/facebook"
+)
+
+type (
+	Params struct {
+		Endpoint string
+		Params   map[string]interface{}
+	}
+
+	// BatchParams comment pending
+	BatchParams struct {
+		Method      string
+		RelativeUrl string
+	}
+)
+
+func NewParams(endpoint string, params map[string]interface{}) Params {
+	return Params{endpoint, params}
+}
+
+func NewBatchParams(endpoint string) BatchParams {
+	return BatchParams{RelativeUrl: endpoint}
+}
+
+func (p BatchParams) ToFBParams() facebookLib.Params {
+	if p.Method == "" {
+		p.Method = "GET"
+	}
+
+	p.RelativeUrl = fmt.Sprintf("%s/%s", facebookAPIVersion, p.RelativeUrl)
+
+	return facebookLib.Params{
+		"method":       p.Method,
+		"relative_url": p.RelativeUrl,
+	}
+}
+
+func (p Params) ToFBParams() facebookLib.Params {
+	return facebookLib.MakeParams(p.Params)
+}

--- a/params.go
+++ b/params.go
@@ -6,6 +6,7 @@ import (
 )
 
 type (
+	// Params comment pending
 	Params struct {
 		Endpoint string
 		Params   map[string]interface{}
@@ -18,15 +19,18 @@ type (
 	}
 )
 
+// NewParams comment pending
 func NewParams(endpoint string, params map[string]interface{}) Params {
 	return Params{endpoint, params}
 }
 
+// NewBatchParams comment pending
 func NewBatchParams(endpoint string) BatchParams {
 	return BatchParams{RelativeUrl: endpoint}
 }
 
-func (p BatchParams) ToFBParams() facebookLib.Params {
+// ToFbParams comment pending
+func (p BatchParams) ToFbParams() facebookLib.Params {
 	if p.Method == "" {
 		p.Method = "GET"
 	}
@@ -39,6 +43,7 @@ func (p BatchParams) ToFBParams() facebookLib.Params {
 	}
 }
 
-func (p Params) ToFBParams() facebookLib.Params {
+// ToFbParams comment pending
+func (p Params) ToFbParams() facebookLib.Params {
 	return facebookLib.MakeParams(p.Params)
 }

--- a/post.go
+++ b/post.go
@@ -31,59 +31,39 @@ func NewPostFromResult(result facebookLib.Result) Post {
 }
 
 // GenerateCommentsParams comment pending
-func (p Post) GenerateCommentsParams() facebookLib.Params {
-	return facebookLib.Params{
-		"method":       facebookLib.GET,
-		"relative_url": fmt.Sprintf("%s/comments?summary=true&filter=stream", p.ID),
-	}
+func (p Post) GenerateCommentsParams() BatchParams {
+	return NewBatchParams(fmt.Sprintf("%s/comments?summary=true&filter=stream", p.ID))
 }
 
 // GenerateInsightParams comment pending
-func (p Post) GenerateInsightParams() facebookLib.Params {
-	return facebookLib.Params{
-		"method":       facebookLib.GET,
-		"relative_url": fmt.Sprintf("%s/insights/post_video_views_unique,post_engaged_users,post_video_complete_views_organic,post_video_complete_views_paid,post_consumptions,post_impressions,post_impressions_paid,post_impressions_unique,post_impressions_paid_unique,post_video_views,post_video_views_paid,post_video_views_organic,post_video_view_time,post_video_avg_time_watched,post_stories_by_action_type?period=lifetime&limit=20", p.ID),
-	}
+func (p Post) GenerateInsightParams() BatchParams {
+	return NewBatchParams(fmt.Sprintf("%s/insights/post_video_views_unique,post_engaged_users,post_video_complete_views_organic,post_video_complete_views_paid,post_consumptions,post_impressions,post_impressions_paid,post_impressions_unique,post_impressions_paid_unique,post_video_views,post_video_views_paid,post_video_views_organic,post_video_view_time,post_video_avg_time_watched,post_stories_by_action_type?period=lifetime&limit=20", p.ID))
 }
 
 // GenerateParams comments pending
-func (p *Post) GenerateParams() facebookLib.Params {
-	return facebookLib.Params{
-		"method":       facebookLib.GET,
-		"relative_url": fmt.Sprintf("%s?fields=%s", p.ID, "object_id,message"),
-	}
+func (p *Post) GenerateParams() BatchParams {
+	return NewBatchParams(fmt.Sprintf("%s?fields=%s", p.ID, "object_id,message"))
 }
 
 // GenerateReactionBreakdownParams comment pending
-func (p Post) GenerateReactionBreakdownParams() []facebookLib.Params {
-	var params []facebookLib.Params
+func (p Post) GenerateReactionBreakdownParams() []BatchParams {
+	var params []BatchParams
 
 	for _, reaction := range p.ReactionTypes() {
-		params = append(params,
-			facebookLib.Params{
-				"method":       facebookLib.GET,
-				"relative_url": fmt.Sprintf("%s/reactions?limit=0&summary=total_count&type=%s", p.ID, reaction),
-			},
-		)
+		params = append(params, NewBatchParams(fmt.Sprintf("%s/reactions?limit=0&summary=total_count&type=%s", p.ID, reaction)))
 	}
 
 	return params
 }
 
 // GenerateSharesParams comment pending
-func (p Post) GenerateSharesParams() facebookLib.Params {
-	return facebookLib.Params{
-		"method":       facebookLib.GET,
-		"relative_url": fmt.Sprintf("%s/sharedposts", p.ID),
-	}
+func (p Post) GenerateSharesParams() BatchParams {
+	return NewBatchParams(fmt.Sprintf("%s/sharedposts", p.ID))
 }
 
 // GenerateTotalReactionsParams comment pending
-func (p Post) GenerateTotalReactionsParams() facebookLib.Params {
-	return facebookLib.Params{
-		"method":       facebookLib.GET,
-		"relative_url": fmt.Sprintf("%s/reactions?limit=0&summary=total_count", p.ID),
-	}
+func (p Post) GenerateTotalReactionsParams() BatchParams {
+	return NewBatchParams(fmt.Sprintf("%s/reactions?limit=0&summary=total_count", p.ID))
 }
 
 // ParseResults comment pending

--- a/post_batch.go
+++ b/post_batch.go
@@ -1,7 +1,5 @@
 package fbintegration
 
-import facebookLib "github.com/huandu/facebook"
-
 type (
 	// PostBatch comment pending
 	PostBatch struct {
@@ -37,8 +35,8 @@ func GeneratePostBatchSlices(posts []*Post, size int) []PostBatch {
 }
 
 // EngagementParams comment pending
-func (p PostBatch) EngagementParams() []facebookLib.Params {
-	var params []facebookLib.Params
+func (p PostBatch) EngagementParams() []BatchParams {
+	var params []BatchParams
 
 	for i := 0; i < len(p.Posts); i++ {
 		params = append(params, p.Posts[i].GenerateCommentsParams())
@@ -49,8 +47,8 @@ func (p PostBatch) EngagementParams() []facebookLib.Params {
 }
 
 // TargetingParams comment pending
-func (p PostBatch) TargetingParams() []facebookLib.Params {
-	var params []facebookLib.Params
+func (p PostBatch) TargetingParams() []BatchParams {
+	var params []BatchParams
 
 	for i := 0; i < len(p.Posts); i++ {
 		ad := Ad{ID: p.Posts[i].AdID, AdsetID: p.Posts[i].AdsetID}
@@ -61,8 +59,8 @@ func (p PostBatch) TargetingParams() []facebookLib.Params {
 }
 
 // InsightParams comment pending
-func (p PostBatch) InsightParams() []facebookLib.Params {
-	var params []facebookLib.Params
+func (p PostBatch) InsightParams() []BatchParams {
+	var params []BatchParams
 
 	for i := 0; i < len(p.Posts); i++ {
 		params = append(params, p.Posts[i].GenerateInsightParams())
@@ -72,8 +70,8 @@ func (p PostBatch) InsightParams() []facebookLib.Params {
 }
 
 // ReactionBreakdownParams comment pending
-func (p PostBatch) ReactionBreakdownParams() []facebookLib.Params {
-	var params []facebookLib.Params
+func (p PostBatch) ReactionBreakdownParams() []BatchParams {
+	var params []BatchParams
 
 	for i := 0; i < len(p.Posts); i++ {
 		for _, p := range p.Posts[i].GenerateReactionBreakdownParams() {
@@ -85,8 +83,8 @@ func (p PostBatch) ReactionBreakdownParams() []facebookLib.Params {
 }
 
 // TotalReactionsParams comment pending
-func (p PostBatch) TotalReactionsParams() []facebookLib.Params {
-	var params []facebookLib.Params
+func (p PostBatch) TotalReactionsParams() []BatchParams {
+	var params []BatchParams
 
 	for i := 0; i < len(p.Posts); i++ {
 		params = append(params, p.Posts[i].GenerateTotalReactionsParams())
@@ -96,8 +94,8 @@ func (p PostBatch) TotalReactionsParams() []facebookLib.Params {
 }
 
 // TotalAdInsightsParams comment pending
-func (p PostBatch) TotalAdInsightsParams() []facebookLib.Params {
-	var params []facebookLib.Params
+func (p PostBatch) TotalAdInsightsParams() []BatchParams {
+	var params []BatchParams
 
 	for i := 0; i < len(p.Posts); i++ {
 		ad := Ad{ID: p.Posts[i].AdID}
@@ -108,8 +106,8 @@ func (p PostBatch) TotalAdInsightsParams() []facebookLib.Params {
 }
 
 // TotalAdInsightsBreakDownParams comment pending
-func (p PostBatch) TotalAdInsightsBreakDownParams() []facebookLib.Params {
-	var params []facebookLib.Params
+func (p PostBatch) TotalAdInsightsBreakDownParams() []BatchParams {
+	var params []BatchParams
 
 	for i := 0; i < len(p.Posts); i++ {
 		ad := Ad{ID: p.Posts[i].AdID}


### PR DESCRIPTION
### Problem

We're calling the API without a version number in batch calls, we shouldn't be doing this.

### Solution

Refactor the params usage to have a single struct for `BatchParams` that adds the version number to any relative url.