### PR TITLE
Correct batch arithmetic & guard against missing fields

### DIFF
--- a/ad.go
+++ b/ad.go
@@ -28,7 +28,7 @@ func NewAd(result *facebookLib.Result) Ad {
 	ad := Ad{
 		id,
 		adsetID,
-		&Creative{creativeID, "", ""},
+		&Creative{ID: creativeID},
 		&Post{},
 	}
 

--- a/brand_ads.go
+++ b/brand_ads.go
@@ -50,15 +50,12 @@ func (ba *BrandAds) GenerateSlices(size int) []AdBatch {
 	startIndex := 0
 	endIndex := size
 
-	for i := 0; i < batchAmount; i++ {
-		var ads []Ad
-		if batchAmount == 1 {
-			ads = ba.Ads
-		} else {
-			ads = ba.Ads[startIndex:endIndex]
-		}
+	if len(ba.Ads) < size {
+		endIndex = len(ba.Ads)
+	}
 
-		batch := AdBatch{ads}
+	for i := 0; i < batchAmount; i++ {
+		batch := AdBatch{ba.Ads[startIndex:endIndex]}
 		adBatch = append(adBatch, batch)
 
 		startIndex += size

--- a/brand_ads.go
+++ b/brand_ads.go
@@ -2,6 +2,7 @@ package fbintegration
 
 import (
 	"fmt"
+	"math"
 )
 
 type (
@@ -44,12 +45,20 @@ func (ba *BrandAds) Add(ad Ad) {
 func (ba *BrandAds) GenerateSlices(size int) []AdBatch {
 	var adBatch []AdBatch
 
-	batchAmount := len(ba.Ads) / size
+	batchAmount := int(math.Ceil(float64(len(ba.Ads)) / float64(size)))
+
 	startIndex := 0
 	endIndex := size
 
 	for i := 0; i < batchAmount; i++ {
-		batch := AdBatch{ba.Ads[startIndex:endIndex]}
+		var ads []Ad
+		if batchAmount == 1 {
+			ads = ba.Ads
+		} else {
+			ads = ba.Ads[startIndex:endIndex]
+		}
+
+		batch := AdBatch{ads}
 		adBatch = append(adBatch, batch)
 
 		startIndex += size

--- a/creative.go
+++ b/creative.go
@@ -11,9 +11,19 @@ const videoType = "VIDEO"
 type (
 	// Creative comment pending
 	Creative struct {
-		ID         string `facebook:"id"`
-		ObjectType string `facebook:"object_type"`
-		PostID     string `facebook:"effective_object_story_id"`
+		ID              string                  `facebook:"id"`
+		ObjectStorySpec CreativeObjectStorySpec `facebook:"object_story_spec"`
+		ObjectType      string                  `facebook:"object_type"`
+		PostID          string                  `facebook:"effective_object_story_id"`
+	}
+
+	CreativeObjectStorySpec struct {
+		VideoData CreativeObjectVideoData `facebook:"video_data"`
+	}
+
+	CreativeObjectVideoData struct {
+		VideoID     string `facebook:"video_id"`
+		Description string `facebook:"description"`
 	}
 )
 
@@ -26,7 +36,7 @@ func NewCreativeFromResult(result facebookLib.Result) Creative {
 
 // GenerateParams comments pending
 func (c *Creative) GenerateParams() BatchParams {
-	return NewBatchParams(fmt.Sprintf("%s?fields=%s", c.ID, "object_id,object_type,effective_object_story_id"))
+	return NewBatchParams(fmt.Sprintf("%s?fields=%s", c.ID, "object_id,object_type,effective_object_story_id,object_story_spec"))
 }
 
 // IsVideo comment pending


### PR DESCRIPTION
### Problem

* Batch wasn't being divided correctly, so for a single page the batch amount was 0 instead of 1.
* We weren't using the correct object id.
* Few fields weren't being guarded against.

### Solution

* `Ceil` the result of dividing the count of ads by batch size.
* Use the `video_id` from `object_story_spec` field of the `AdCreative`.
* Guard against some extra missing fields.