### PR TITLE
Change amount if last page and add errors for api_reponse

### DIFF
--- a/api_response.go
+++ b/api_response.go
@@ -45,6 +45,10 @@ func (a *APIResponse) Data(paginate bool) ([]facebookLib.Result, error) {
 	var results []facebookLib.Result
 	results = append(results, *a.Result)
 
+	if err := results[0].Err(); err != nil {
+		return []facebookLib.Result{}, err
+	}
+
 	return results, nil
 }
 

--- a/brand_ads.go
+++ b/brand_ads.go
@@ -60,6 +60,10 @@ func (ba *BrandAds) GenerateSlices(size int) []AdBatch {
 
 		startIndex += size
 		endIndex += size
+
+		if endIndex > len(ba.Ads) {
+			endIndex = len(ba.Ads)
+		}
 	}
 
 	return adBatch

--- a/creative.go
+++ b/creative.go
@@ -46,3 +46,20 @@ func (c *Creative) IsVideo() bool {
 	}
 	return false
 }
+
+// HasObjectID comment pending
+func (c Creative) HasObjectID() bool {
+	if c.ObjectStorySpec.VideoData.VideoID != "" {
+		return true
+	}
+	return false
+}
+
+// ObjectID comment pending
+func (c Creative) ObjectID() string {
+	if c.HasObjectID() {
+		return c.ObjectStorySpec.VideoData.VideoID
+	}
+
+	return ""
+}

--- a/post.go
+++ b/post.go
@@ -43,7 +43,7 @@ func (p Post) GenerateInsightParams() BatchParams {
 
 // GenerateParams comment pending
 func (p *Post) GenerateParams() BatchParams {
-	return NewBatchParams(fmt.Sprintf("%s?fields=%s", p.ID, "message"))
+	return NewBatchParams(fmt.Sprintf("%s?fields=%s", p.ID, "object_id,message"))
 }
 
 // GeneratePostCreatedTimestampParams comment pending


### PR DESCRIPTION
### Problem

Batch requests on the last batch had the wrong end index meaning there was a slice with padded nil values in it up to the batch size, causing errors in `fb-publisher`. We also needed to know about errors on the graph when calling `Data` on the `ApiReponse` struct.

### Solution

* Propagate the error from the graph response.
* If the `endIndex` in a batch request is more than the size of the array, favour the size of the array.
* Helper methods for getting `ObjectID` from a creative.
* Return object ID in post so we can use if no object ID returned in `ad creative`.