### PR TITLE
Use facebook SDK tags to buld up struct of payload

### DIFF
--- a/ad_targeting.go
+++ b/ad_targeting.go
@@ -34,7 +34,7 @@ type (
 			Interests []struct {
 				Name string `facebook:"name"`
 			} `facebook:"interests"`
-			FlexibleSpecs []struct {
+			FlexibleSpec []struct {
 				Interests []struct {
 					Name string `facebook:"name"`
 				} `facebook:"interests"`
@@ -50,8 +50,8 @@ func (atp AdTargetingPayload) HasInterests() bool {
 
 // HasFlexibleInterests comment pending
 func (atp AdTargetingPayload) HasFlexibleInterests() bool {
-	if len(atp.Targeting.FlexibleSpecs) > 0 {
-		for _, flexibleSpec := range atp.Targeting.FlexibleSpecs {
+	if len(atp.Targeting.FlexibleSpec) > 0 {
+		for _, flexibleSpec := range atp.Targeting.FlexibleSpec {
 			if len(flexibleSpec.Interests) > 0 {
 				return true
 			}
@@ -63,9 +63,9 @@ func (atp AdTargetingPayload) HasFlexibleInterests() bool {
 // FlexibleInterests comment pending
 func (atp AdTargetingPayload) FlexibleInterests() []string {
 	var interests []string
-	for index, flexibleSpec := range atp.Targeting.FlexibleSpecs {
+	for index, flexibleSpec := range atp.Targeting.FlexibleSpec {
 		if len(flexibleSpec.Interests) > 0 {
-			for _, interest := range atp.Targeting.FlexibleSpecs[index].Interests {
+			for _, interest := range atp.Targeting.FlexibleSpec[index].Interests {
 				interests = append(interests, interest.Name)
 			}
 		}

--- a/ad_targeting.go
+++ b/ad_targeting.go
@@ -1,32 +1,97 @@
 package fbintegration
 
 import (
-	"fmt"
 	facebookLib "github.com/huandu/facebook"
 	"github.com/pariz/gountries"
-	"reflect"
 )
 
 type (
 	// AdTargeting comment pending
 	AdTargeting struct {
 		Locations []string `json:"locations"`
-		AgeMin    float64  `json:"age_min"`
-		AgeMax    float64  `json:"age_max"`
+		AgeMin    int      `json:"age_min"`
+		AgeMax    int      `json:"age_max"`
 		Interests []string `json:"interests"`
+		Genders   struct {
+			Male   bool `json:"male"`
+			Female bool `json:"female"`
+		} `json:"genders"`
+	}
+
+	// AdTargetingPayload comment pending
+	AdTargetingPayload struct {
+		Targeting struct {
+			GeoLocations struct {
+				Countries     []string `facebook:"countries"`
+				CountryGroups []string `facebook"country_groups"`
+				Cities        []struct {
+					Name string `facebook:"name"`
+				} `facebook:"cities"`
+			} `facebook:"geo_locations"`
+			AgeMin    int   `facebook:"age_min"`
+			AgeMax    int   `facebook:"age_max"`
+			Genders   []int `facebook:"genders"`
+			Interests []struct {
+				Name string `facebook:"name"`
+			} `facebook:"interests"`
+			FlexibleSpecs []struct {
+				Interests []struct {
+					Name string `facebook:"name"`
+				} `facebook:"interests"`
+			} `facebook:"flexible_spec"`
+		} `facebook:"targeting"`
 	}
 )
+
+func (atp AdTargetingPayload) HasInterests() bool {
+	return len(atp.Targeting.Interests) > 0
+}
+
+func (atp AdTargetingPayload) HasFlexibleInterests() bool {
+	if len(atp.Targeting.FlexibleSpecs) > 0 {
+		for _, flexibleSpec := range atp.Targeting.FlexibleSpecs {
+			if len(flexibleSpec.Interests) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (atp AdTargetingPayload) FlexibleInterests() []string {
+	var interests []string
+	for index, flexibleSpec := range atp.Targeting.FlexibleSpecs {
+		if len(flexibleSpec.Interests) > 0 {
+			for _, interest := range atp.Targeting.FlexibleSpecs[index].Interests {
+				interests = append(interests, interest.Name)
+			}
+		}
+	}
+
+	return interests
+}
 
 // NewAdTargetingFromResult comment pending
 func NewAdTargetingFromResult(results *facebookLib.Result) AdTargeting {
 	query := gountries.New()
 	adTargeting := AdTargeting{}
 
-	countries := results.Get("targeting.geo_locations.countries")
-	if countries != nil {
-		countryList := reflect.ValueOf(countries)
-		for i := 0; i < countryList.Len(); i++ {
-			country := results.Get(fmt.Sprintf("targeting.geo_locations.countries.%d", i)).(string)
+	var adTargetingPayload AdTargetingPayload
+	results.DecodeField("", &adTargetingPayload)
+	targeting := adTargetingPayload.Targeting
+
+	if adTargetingPayload.HasInterests() {
+		for _, interest := range targeting.Interests {
+			adTargeting.Interests = append(adTargeting.Interests, interest.Name)
+		}
+	}
+
+	if adTargetingPayload.HasFlexibleInterests() {
+		adTargeting.Interests = append(adTargeting.Interests, adTargetingPayload.FlexibleInterests()...)
+	}
+
+	if len(targeting.GeoLocations.Countries) > 0 {
+		for _, country := range targeting.GeoLocations.Countries {
 			countryName, err := query.FindCountryByAlpha(country)
 			if err != nil {
 				adTargeting.Locations = append(adTargeting.Locations, country)
@@ -36,36 +101,28 @@ func NewAdTargetingFromResult(results *facebookLib.Result) AdTargeting {
 		}
 	}
 
-	ageMin := results.Get("targeting.age_min")
-	if ageMin != nil {
-		adTargeting.AgeMin = ageMin.(float64)
+	if len(targeting.GeoLocations.Cities) > 0 {
+		for _, city := range targeting.GeoLocations.Cities {
+			adTargeting.Locations = append(adTargeting.Locations, city.Name)
+		}
 	}
 
-	ageMax := results.Get("targeting.age_max")
-	if ageMax != nil {
-		adTargeting.AgeMax = ageMax.(float64)
-	}
+	adTargeting.AgeMin = targeting.AgeMin
+	adTargeting.AgeMax = targeting.AgeMax
 
-	interests := results.Get("targeting.interests")
-	if interests != nil {
-		adTargeting.Interests = addInterests(interests, results)
-	}
-
-	flexibleInterests := results.Get("targeting.flexible_spec.interests")
-	if flexibleInterests != nil {
-		adTargeting.Interests = addInterests(flexibleInterests, results)
+	if len(targeting.Genders) > 0 {
+		for _, gender := range targeting.Genders {
+			switch gender {
+			case 1:
+				adTargeting.Genders.Male = true
+			case 2:
+				adTargeting.Genders.Female = true
+			}
+		}
+	} else {
+		adTargeting.Genders.Male = true
+		adTargeting.Genders.Female = true
 	}
 
 	return adTargeting
-}
-
-func addInterests(interests interface{}, results *facebookLib.Result) []string {
-	var filteredInterests []string
-	interestsList := reflect.ValueOf(interests)
-	for i := 0; i < interestsList.Len(); i++ {
-		interest := results.Get(fmt.Sprintf("targeting.interests.%d.name", i)).(string)
-		filteredInterests = append(filteredInterests, interest)
-	}
-
-	return filteredInterests
 }

--- a/ad_targeting.go
+++ b/ad_targeting.go
@@ -43,10 +43,12 @@ type (
 	}
 )
 
+// HasInterests comment pending
 func (atp AdTargetingPayload) HasInterests() bool {
 	return len(atp.Targeting.Interests) > 0
 }
 
+// HasFlexibleInterests comment pending
 func (atp AdTargetingPayload) HasFlexibleInterests() bool {
 	if len(atp.Targeting.FlexibleSpecs) > 0 {
 		for _, flexibleSpec := range atp.Targeting.FlexibleSpecs {
@@ -58,6 +60,7 @@ func (atp AdTargetingPayload) HasFlexibleInterests() bool {
 	return false
 }
 
+// FlexibleInterests comment pending
 func (atp AdTargetingPayload) FlexibleInterests() []string {
 	var interests []string
 	for index, flexibleSpec := range atp.Targeting.FlexibleSpecs {

--- a/posts_summary.go
+++ b/posts_summary.go
@@ -69,18 +69,16 @@ func NewPostsSummary(posts []*Post) PostsSummary {
 func calculateViewRate(totalUniqueVideoViews float64, totalPeopleReached float64) float64 {
 	if totalUniqueVideoViews > 0 && totalPeopleReached > 0 {
 		return (totalUniqueVideoViews / totalPeopleReached) * 100
-	} else {
-		return 0
 	}
+	return 0
 }
 
 // calculateEngagementRate comment pending
 func calculateEngagementRate(totalPostConsumptions float64, totalPostEngagements float64, totalPeopleReached float64) float64 {
 	if totalPostConsumptions > 0 && totalPostEngagements > 0 && totalPeopleReached > 0 {
 		return ((totalPostConsumptions + totalPostEngagements) / totalPeopleReached) * 100
-	} else {
-		return 0
 	}
+	return 0
 }
 
 // ToJSON comment pending

--- a/posts_summary.go
+++ b/posts_summary.go
@@ -67,12 +67,20 @@ func NewPostsSummary(posts []*Post) PostsSummary {
 
 // calculateViewRate comment pending
 func calculateViewRate(totalUniqueVideoViews float64, totalPeopleReached float64) float64 {
-	return (totalUniqueVideoViews / totalPeopleReached) * 100
+	if totalUniqueVideoViews > 0 && totalPeopleReached > 0 {
+		return (totalUniqueVideoViews / totalPeopleReached) * 100
+	} else {
+		return 0
+	}
 }
 
 // calculateEngagementRate comment pending
 func calculateEngagementRate(totalPostConsumptions float64, totalPostEngagements float64, totalPeopleReached float64) float64 {
-	return ((totalPostConsumptions + totalPostEngagements) / totalPeopleReached) * 100
+	if totalPostConsumptions > 0 && totalPostEngagements > 0 && totalPeopleReached > 0 {
+		return ((totalPostConsumptions + totalPostEngagements) / totalPeopleReached) * 100
+	} else {
+		return 0
+	}
 }
 
 // ToJSON comment pending


### PR DESCRIPTION
### Problem

The interests for the demo ad didn't populate correctly as we weren't querying the correct node in the payload.

### Solution

Use the tagged approach that the facebook SDK provides and pull from either `Interests` node or `FlexibleSpecs` node.