### PR TITLE
Account for video_id being used on multiple posts

### DIFF
--- a/brand_ads.go
+++ b/brand_ads.go
@@ -91,11 +91,13 @@ func (ba *BrandAds) FindByPostID(postID string) *Ad {
 }
 
 // FindByObjectID comment pending
-func (ba *BrandAds) FindByObjectID(objectID string) *Ad {
+func (ba *BrandAds) FindByObjectID(objectID string) []*Ad {
+	var ads []*Ad
+
 	for i, ad := range ba.Ads {
 		if ad.Post.ObjectID == objectID {
-			return &ba.Ads[i]
+			ads = append(ads, &ba.Ads[i])
 		}
 	}
-	return nil
+	return ads
 }


### PR DESCRIPTION
### Problem

Two ads were created in different adsets using the same video. Only one of them was shown in the insights tab, this was because we return the first match when looking them up based on the `facebook_id`.

### Solution

* Return all matches based on that `facebook_id`.