### PR TITLE
Return params grouped by postID

### DIFF
--- a/post_batch.go
+++ b/post_batch.go
@@ -70,16 +70,14 @@ func (p PostBatch) InsightParams() []BatchParams {
 }
 
 // ReactionBreakdownParams comment pending
-func (p PostBatch) ReactionBreakdownParams() []BatchParams {
-	var params []BatchParams
+func (p PostBatch) ReactionBreakdownParams() map[string][]BatchParams {
+	postParams := make(map[string][]BatchParams, len(p.Posts))
 
 	for i := 0; i < len(p.Posts); i++ {
-		for _, p := range p.Posts[i].GenerateReactionBreakdownParams() {
-			params = append(params, p)
-		}
+		postParams[p.Posts[i].ID] = p.Posts[i].GenerateReactionBreakdownParams()
 	}
 
-	return params
+	return postParams
 }
 
 // TotalReactionsParams comment pending


### PR DESCRIPTION
### Problem

`fb-consumer` had some issues now we're starting to process a larger number of ads, this was due to creating a batch of 20 posts and 7 separate calls for the reaction stats.

### Solution

Return the breakdown params groups by `postID` so we can split the requests up.