### PR TITLE
Use TotalReactions count instead of just like count

### DIFF
--- a/post.go
+++ b/post.go
@@ -96,7 +96,7 @@ func (p *Post) ParseResults() {
 
 	p.Data.PeopleReachedOrganic = (p.Data.PeopleReached - p.Data.PeopleReachedPaid)
 
-	p.Data.Reactions = p.getActionTypeTotal("like")
+	p.Data.Reactions = p.getReactionsTotal(p.Results.TotalReactions)
 
 	p.Data.ReactionsBreakdown = make(map[string]float64)
 	for i, reactionType := range p.ReactionTypes() {


### PR DESCRIPTION
### Problem

For the total count reactions count we were using the total likes and not incorporating the other reactions.

### Solution

* Use result from `TotalReactions`.