### PR TITLE
Get shares and comment count from correct locations

### DIFF
--- a/post_batch.go
+++ b/post_batch.go
@@ -115,7 +115,8 @@ func (p PostBatch) TotalAdInsightsBreakDownParams() []BatchParams {
 	return params
 }
 
-// PostDataParams comment pending
+// PostDataParams return a slice of BatchParams for post realted
+// fields.
 func (p PostBatch) PostDataParams() []BatchParams {
 	var params []BatchParams
 

--- a/post_batch.go
+++ b/post_batch.go
@@ -34,13 +34,13 @@ func GeneratePostBatchSlices(posts []*Post, size int) []PostBatch {
 	return postBatches
 }
 
-// EngagementParams comment pending
-func (p PostBatch) EngagementParams() []BatchParams {
+// CommentParams returns a slice of BatchParams of comment requests
+// for each post.
+func (p PostBatch) CommentParams() []BatchParams {
 	var params []BatchParams
 
 	for i := 0; i < len(p.Posts); i++ {
 		params = append(params, p.Posts[i].GenerateCommentsParams())
-		params = append(params, p.Posts[i].GenerateSharesParams())
 	}
 
 	return params
@@ -115,12 +115,12 @@ func (p PostBatch) TotalAdInsightsBreakDownParams() []BatchParams {
 	return params
 }
 
-// PostCreatedTimestampParams comment pending
-func (p PostBatch) PostCreatedTimestampParams() []BatchParams {
+// PostDataParams comment pending
+func (p PostBatch) PostDataParams() []BatchParams {
 	var params []BatchParams
 
 	for i := 0; i < len(p.Posts); i++ {
-		params = append(params, p.Posts[i].GeneratePostCreatedTimestampParams())
+		params = append(params, p.Posts[i].GeneratePostParams())
 	}
 
 	return params

--- a/post_results.go
+++ b/post_results.go
@@ -8,12 +8,12 @@ type (
 	// PostResults comment pending
 	PostResults struct {
 		Targeting           *facebookLib.Result
-		Engagement          []*facebookLib.Result
+		Comments            *facebookLib.Result
 		Insights            *facebookLib.Result
 		AdInsights          *facebookLib.Result
 		AdBreakdownInsights *facebookLib.Result
 		ReactionBreakdown   []*facebookLib.Result
 		TotalReactions      *facebookLib.Result
-		CreatedTimestamp    *facebookLib.Result
+		PostData            *facebookLib.Result
 	}
 )


### PR DESCRIPTION
### Problem

The share and comment we were getting from the insights didn't align with what the Facebook UI was showing.

### Solution

* Get both `created_time` and `share` fields from the post and use `share` for the share count.
* Call the `/comments` edge for a post to get the comment count.