### PR TITLE
Fix slice creating extra nil entries

### DIFF
--- a/post_batch.go
+++ b/post_batch.go
@@ -28,7 +28,11 @@ func GeneratePostBatchSlices(posts []*Post, size int) []PostBatch {
 
 		postBatches = append(postBatches, batch)
 		start += size
-		end += size
+		if (end + size) > len(posts) {
+			end += len(posts) - end
+		} else {
+			end += size
+		}
 	}
 
 	return postBatches


### PR DESCRIPTION
### Problem

We had `38` posts to process and the two batches we ended up with from `GeneratePostBatchSlices` were both `20` items in length, the second slice containing two `nil` items causing `fb-consumer` to panic.

### Solution

* Each time we increment the `end` value for the slice, check that it isn't greater than the total length of the posts. If it is just set the `end` var to the difference.