### PR TITLE
Check that reflected value is valid before continuing

### DIFF
--- a/post.go
+++ b/post.go
@@ -253,20 +253,22 @@ func (p Post) getInsightsValue(key string) map[string]interface{} {
 	data := p.Results.Insights.Get("data")
 	slice := reflect.ValueOf(data)
 
-	for i := 0; i < slice.Len(); i++ {
-		query := fmt.Sprintf("data.%d.name", i)
-		name := p.Results.Insights.Get(query)
+	if slice.Valid() {
+		for i := 0; i < slice.Len(); i++ {
+			query := fmt.Sprintf("data.%d.name", i)
+			name := p.Results.Insights.Get(query)
 
-		if name == key {
-			query = fmt.Sprintf("data.%d.values", i)
-			values := p.Results.Insights.Get(query).([]interface{})
+			if name == key {
+				query = fmt.Sprintf("data.%d.values", i)
+				values := p.Results.Insights.Get(query).([]interface{})
 
-			if len(values) > 0 {
-				query = fmt.Sprintf("data.%d.values.0", i)
-				return p.Results.Insights.Get(query).(map[string]interface{})
+				if len(values) > 0 {
+					query = fmt.Sprintf("data.%d.values.0", i)
+					return p.Results.Insights.Get(query).(map[string]interface{})
+				}
+
+				return nil
 			}
-
-			return nil
 		}
 	}
 


### PR DESCRIPTION
### Problem

The insights data may not exist for a given post, at the moment we don't check this before trying to process the data.

### Solution

* Check reflected Value has an actual value before processing.

### Notes

```go
[fb-consumer-2]2016-11-03T10:56:33.212446349Z [fb-consumer] 2016/11/03 10:56:33 *reflect.ValueError reflect: call of reflect.Value.Len on zero Value
[fb-consumer-2]2016-11-03T10:56:33.212464849Z /usr/local/go/src/runtime/panic.go:458 (0x42dea3)
[fb-consumer-2]2016-11-03T10:56:33.212471688Z /usr/local/go/src/reflect/value.go:1014 (0x4ff504)
[fb-consumer-2]2016-11-03T10:56:33.212476871Z /go/src/github.com/vidsy/fb-consumer/vendor/github.com/vidsy/fbintegration/post.go:256 (0x4e175f)
[fb-consumer-2]2016-11-03T10:56:33.212482236Z /go/src/github.com/vidsy/fb-consumer/vendor/github.com/vidsy/fbintegration/post.go:88 (0x4e00ee)
[fb-consumer-2]2016-11-03T10:56:33.212487349Z /go/src/github.com/vidsy/fb-consumer/poller.go:356 (0x4056ae)
[fb-consumer-2]2016-11-03T10:56:33.212492288Z /go/src/github.com/vidsy/fb-consumer/poller.go:49 (0x401e04)
[fb-consumer-2]2016-11-03T10:56:33.212497008Z /go/src/github.com/vidsy/fb-consumer/main.go:36 (0x401391)
[fb-consumer-2]2016-11-03T10:56:33.212511963Z /usr/local/go/src/runtime/proc.go:183 (0x42fb74)
[fb-consumer-2]2016-11-03T10:56:33.212530968Z /usr/local/go/src/runtime/asm_amd64.s:2086 (0x45d4f1)
```